### PR TITLE
Always render header

### DIFF
--- a/src/VirtualTable.tsx
+++ b/src/VirtualTable.tsx
@@ -582,12 +582,12 @@ export default class VirtualTable<TData extends object> extends React.PureCompon
       <div
         className={`${this.className} calculator`}
         ref={this.setContainerRef}
-        style={{...styles.container, visibility: 'hidden'}}
+        style={styles.container}
       >
         <div className='rvt-virtual-table-container'>
           <table className={tableClassName} style={styles.table}>
             {header}
-            <tbody style={styles.tbody}>
+            <tbody style={{...styles.tbody, visibility: 'hidden'}}>
               {rows}
             </tbody>
           </table>


### PR DESCRIPTION
We always render the header, even when we are calculating height, to indicate that the table is present and has received the schema/props. In the case that we load the page and no rows are passed to the table but the header schema is passed through (resulting in `calculatingHeights` staying equal to true and thus only rendering the calculator), we still want to display the header instead of nothing.