### PR TITLE
Change ceil to round to calculate correct scroll position if zoomed

### DIFF
--- a/src/VirtualTable.tsx
+++ b/src/VirtualTable.tsx
@@ -300,7 +300,7 @@ export default class VirtualTable<TData extends object> extends React.PureCompon
    * @private
    */
   private onScroll(scrollTop: number) {
-    const topRow = Math.ceil(scrollTop / this.state.rowHeight);
+    const topRow = Math.round(scrollTop / this.state.rowHeight);
     this.setTopRow(topRow);
   }
 


### PR DESCRIPTION
Redo to put back rounding as the ceil will cause the top row to jump if the math is off (especially if zoomed)